### PR TITLE
Pass channel and group through method signatures

### DIFF
--- a/src/main/scala/Services.scala
+++ b/src/main/scala/Services.scala
@@ -2,37 +2,30 @@ import zhttp.service.{ChannelFactory, Client, EventLoopGroup}
 import zio.{Tag, ZIO, ZLayer}
 
 trait NumService:
-  val get: ZIO[Any, Throwable, Int]
+  val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, Int]
 
-case class NumServiceLive(layers: ZLayer[Any, Nothing, ChannelFactory & EventLoopGroup]) extends NumService:
+case class NumServiceLive() extends NumService:
   val url = "https://random-num-x5ht4amjia-uc.a.run.app/"
-  val get: ZIO[Any, Throwable, Int] =
-    val z =
+  val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, Int] =
       for
         resp <- Client.request(url)
         body <- resp.bodyAsString
       yield body.toInt
 
-    z.provideLayer(layers)
-
 object NumService:
-  val get: ZIO[NumService, Throwable, Int] = ZIO.serviceWithZIO[NumService](_.get)
-
+  val get: ZIO[NumService & ChannelFactory & EventLoopGroup, Throwable, Int] = ZIO.serviceWithZIO[NumService](_.get)
 
 trait WordService:
-  val get: ZIO[Any, Throwable, String]
+  val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, String]
 
-case class WordServiceLive(layers: ZLayer[Any, Nothing, ChannelFactory & EventLoopGroup]) extends WordService:
+case class WordServiceLive() extends WordService:
   val url = "https://random-word-x5ht4amjia-uc.a.run.app/"
-  val get: ZIO[Any, Throwable, String] =
-    val z =
-      for
-        resp <- Client.request(url)
-        body <- resp.bodyAsString
-      yield body
-
-    z.provideLayer(layers)
+  val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, String] =
+    for
+      resp <- Client.request(url)
+      body <- resp.bodyAsString
+    yield body
 
 object WordService:
-  val get: ZIO[WordService, Throwable, String] = ZIO.serviceWithZIO[WordService](_.get)
+  val get: ZIO[WordService & ChannelFactory & EventLoopGroup, Throwable, String] = ZIO.serviceWithZIO[WordService](_.get)
 

--- a/src/main/scala/Services.scala
+++ b/src/main/scala/Services.scala
@@ -1,31 +1,36 @@
 import zhttp.service.{ChannelFactory, Client, EventLoopGroup}
-import zio.{Tag, ZIO, ZLayer}
+import zio.{Tag, ULayer, ZIO, ZLayer}
 
 trait NumService:
   val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, Int]
 
-case class NumServiceLive() extends NumService:
-  val url = "https://random-num-x5ht4amjia-uc.a.run.app/"
-  val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, Int] =
+object NumService:
+  val get: ZIO[NumService & ChannelFactory & EventLoopGroup, Throwable, Int] = ZIO.serviceWithZIO[NumService](_.get)
+  
+  object NumServiceLive extends NumService:
+    val url = "https://random-num-x5ht4amjia-uc.a.run.app/"
+    val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, Int] =
       for
         resp <- Client.request(url)
         body <- resp.bodyAsString
       yield body.toInt
+      
+  val live: ULayer[NumService] = ZLayer.succeed(NumServiceLive)
 
-object NumService:
-  val get: ZIO[NumService & ChannelFactory & EventLoopGroup, Throwable, Int] = ZIO.serviceWithZIO[NumService](_.get)
 
 trait WordService:
   val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, String]
 
-case class WordServiceLive() extends WordService:
-  val url = "https://random-word-x5ht4amjia-uc.a.run.app/"
-  val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, String] =
-    for
-      resp <- Client.request(url)
-      body <- resp.bodyAsString
-    yield body
-
 object WordService:
   val get: ZIO[WordService & ChannelFactory & EventLoopGroup, Throwable, String] = ZIO.serviceWithZIO[WordService](_.get)
+  
+  object WordServiceLive extends WordService:
+    val url = "https://random-word-x5ht4amjia-uc.a.run.app/"
+    val get: ZIO[ChannelFactory & EventLoopGroup, Throwable, String] =
+      for
+        resp <- Client.request(url)
+        body <- resp.bodyAsString
+      yield body
+
+  val live: ULayer[WordService] = ZLayer.succeed(WordServiceLive)
 

--- a/src/main/scala/WebApp.scala
+++ b/src/main/scala/WebApp.scala
@@ -2,7 +2,6 @@ import zhttp.http.{Http, Response}
 import zhttp.service.{ChannelFactory, EventLoopGroup, Server}
 import zio.{ZIO, ZIOAppDefault, ZLayer}
 
-
 object WebApp extends ZIOAppDefault:
 
   def gibberish[E]: ZIO[NumService & WordService & ChannelFactory & EventLoopGroup, Throwable, String] =
@@ -16,10 +15,10 @@ object WebApp extends ZIOAppDefault:
     Http.fromZIO(gibberish.map(Response.text))
 
   def run =
-    Server.start(8080, app).provide(
-      ChannelFactory.auto, 
-      EventLoopGroup.auto(),
-      ZLayer.succeed(NumServiceLive()),
-      ZLayer.succeed(WordServiceLive())
-      
-    ).exitCode
+    Server.start(8080, app)
+      .provide(
+        ChannelFactory.auto,
+        EventLoopGroup.auto(),
+        NumService.live,
+        WordService.live
+      )


### PR DESCRIPTION
I might not be fully grokking how ZIO HTTP expects users to handle `ChannelFactory` & `EventLoopGroup`, but since they have them as an environment requirement of the `request` method, I think it's inevitable that they will percolate through user HTTP methods as well, rather than being something that we plug in to services during their construction-

```
object Client {
  def request(...): ZIO[EventLoopGroup with ChannelFactory, Throwable, Response]
}
```

This doesn't get things down to 10ms, but it's < 1 second.
Dunno if we can actually expect 10ms since it's making multiple requests to other web services in order to construct its own response.